### PR TITLE
Added instructions for mac setup, mac setup script, time measurement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ We suggest you create a virtural environment before installing COFFE.
 ```bash
 cd Coffe && pip install .
 ```
+> **Developers modifying the source code:** use `pip install -e .` instead. This installs COFFE in editable mode so any changes to the source are reflected immediately without reinstalling. If you use a virtual environment manager (e.g. pipenv), make sure to run the install inside the same environment your shell uses to invoke `coffe` — installing into the wrong environment means your changes will be silently ignored.
+
 2. COFFE comes with a docker image, to install it:
 ```bash
 docker build . -t coffe
@@ -86,6 +88,7 @@ coffe pipe <benchmark_name> <output_repo>
 -p <pred_file_1>,...,<pred_file_n> 
 -f <efficient_at_1/speedup> 
 -n <number_of_workers>
+[--measure <instr_count/time>]
 ```
 This command has four phases:
 1. santize the predictions.
@@ -93,9 +96,15 @@ This command has four phases:
 3. evaluate the GPU instruction count based on stressful test cases.
 4. calculate the final metrics.
 
+The `--measure` flag controls how step 3 measures performance. The default is `instr_count` (CPU instruction counting), which requires Linux with perf permissions. Pass `--measure time` to use wall-clock time instead, which works on any system.
+
 For example:
 ```bash
 coffe pipe function Coffe/examples/function -p Coffe/examples/function/GPT-4o.json -f efficient_at_1 -n 8
+```
+To measure wall-clock time instead of instruction count:
+```bash
+coffe pipe function Coffe/examples/function -p Coffe/examples/function/GPT-4o.json -f efficient_at_1 -n 8 --measure time
 ```
 This command evaluates the predictions from GPT-4o on the function-level instances of COFFE. If you want to evaluate other LLMs, please prepare a `JSON` file with the same format as `Coffe/examples/function/GPT-4o.json`. 
 
@@ -155,6 +164,82 @@ This command calculate the efficient@1 or speedup.
 
 **Note:**
 This command requires the index file and the instruction file as COFFE compares the performance of predictions with grouth truth solutions to calculate the metrics.
+
+## Mac Setup
+
+macOS does not support CPU instruction counting via `perf_event_open`, so COFFE uses wall-clock time measurement instead. The setup differs from Linux in two ways: an editable install, and the `--measure time` flag on all pipeline runs.
+
+**Requirements:**
+- macOS (Apple Silicon or Intel)
+- Docker Desktop (must be running before each evaluation)
+- Python 3.10+
+- pipenv (`pip install pipenv`)
+
+### Automated Setup
+
+Run the provided script from the repo root:
+
+```bash
+cd Coffe-3Llamas
+chmod +x setup_mac.sh
+./setup_mac.sh
+```
+
+This handles all steps below automatically.
+
+### Manual Setup
+
+**1. Install COFFE in editable mode**
+
+Install directly into the Python environment your shell uses (not via `pipenv run`):
+
+```bash
+cd Coffe-3Llamas
+pip install -e .
+```
+
+Verify it points to your source files, not a cached copy in `site-packages`:
+
+```bash
+python3 -c "import coffe.main; import inspect; print(inspect.getfile(coffe.main))"
+```
+
+The output should be a path inside your repo (e.g. `.../Coffe-3Llamas/coffe/main.py`), not a `site-packages` path. If it shows `site-packages`, your shell is using a different Python environment — find its `pip` and re-run the install against it (e.g. `/path/to/venv/bin/pip install -e .`).
+
+**2. Build the Mac Docker image**
+
+Use the default `Dockerfile`:
+
+```bash
+docker build --no-cache . -t coffe
+```
+
+You will see a warning about CPU instruction counting — this is expected on Mac.
+
+**3. Initialize COFFE**
+
+Run from your workspace directory (the parent of the repo):
+
+```bash
+cd ..
+coffe init -d Coffe-3Llamas/datasets -w $(pwd) -p Coffe-3Llamas/perf.json
+```
+
+### Running the Pipeline on Mac
+
+Add `--measure time` to all `coffe pipe` commands:
+
+```bash
+coffe pipe function Coffe-3Llamas/examples/function \
+  -p Coffe-3Llamas/examples/function/GPT-4o.json \
+  -f efficient_at_1 \
+  -n 4 \
+  --measure time
+```
+
+This uses wall-clock time instead of CPU instruction count. Results are saved to a file ending with `_STRESSFUL_TIME.json` instead of `_STRESSFUL_INSTRUCTION.json`.
+
+**Note:** Docker Desktop must be open and running before each evaluation.
 
 ## STGen
 

--- a/coffe/main.py
+++ b/coffe/main.py
@@ -34,10 +34,12 @@ def init(args):
     try:
         with Collector() as c:
             time.sleep(0.1)
+        if c.counters.instruction_count <= 0:
+            raise Exception()
+        print(colored("CPU instruction counting is supported on this system.", "green"))
     except:
-        raise OSError(f"Your OS does not support measuring CPU instruction counts.")
-    if c.counters.instruction_count <= 0:
-        raise OSError(f"Your OS does not support measuring CPU instruction counts.")
+        print(colored("Warning: CPU instruction counting is not available on this system. "
+                      "Use --measure time when running the pipeline.", "yellow"))
     
     for benchmark in benchmarks:
         dataset = Dataset(benchmark, data_path = os.path.join(dataset_path, benchmarks[benchmark]["path"]))
@@ -163,6 +165,12 @@ def pipe(args):
 
     args.checked_init = True
 
+    # Determine measurement mode: CPU instruction count (default) or wall-clock time.
+    measure = getattr(args, 'measure', 'instr_count')
+    if sys.platform == 'darwin' and measure == 'instr_count':
+        measure = 'time'
+    result_suffix = "_STRESSFUL_INSTRUCTION.json" if measure == "instr_count" else "_STRESSFUL_TIME.json"
+
     if args.final_metric not in ["speedup", "efficient_at_1"]:
         raise ValueError("The final metric could only be speedup or efficient_at_1 in pipeline mode.")
 
@@ -174,7 +182,7 @@ def pipe(args):
 
     
     print(colored("+++++++++++Step 1: Checking Syntax Errors...", "green"))
-    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace("-f ", "").replace(final_metric, "")
+    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace("-f ", "").replace(final_metric, "").replace("--measure " + measure, "")
     command += " -m compilable_rate"
     args.metric = "compilable_rate"
     print(f"Executing Command: {command}...")
@@ -183,7 +191,7 @@ def pipe(args):
     print(colored("Done!", "green"))
 
     print(colored("+++++++++++Step 2: Checking Correctness...", "green"))
-    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace(args.metric, "correctness").replace("-f ", "").replace(final_metric, "")
+    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace(args.metric, "correctness").replace("-f ", "").replace(final_metric, "").replace("--measure " + measure, "")
     command = command.replace(ori_prediction, ori_prediction.replace(".json", "_SOLUTIONS.json"))
     command += " -m correctness"
     args.prediction = ori_prediction.replace(".json", "_SOLUTIONS.json")
@@ -194,37 +202,38 @@ def pipe(args):
     print(colored("Done!", "green"))
     args.stressful = True
 
-    print(colored("+++++++++++Step 3: Measuring GPU Instruction Count...", "green"))
+    step3_label = "CPU Instruction Count" if measure == "instr_count" else "Execution Time"
+    print(colored(f"+++++++++++Step 3: Measuring {step3_label}...", "green"))
     if "," in ori_prediction:
         dirname = os.path.dirname(ori_prediction.split(",")[-1])
     else:
         dirname = os.path.dirname(ori_prediction)
     dataset_name = args.dataset.replace("/", "_")
     args.prediction = os.path.join(dirname, f"{dataset_name}_all_PASSED_SOLUTIONS.json")
-    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace(args.metric, "instr_count").replace("-f ", "").replace(final_metric, "")
+    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace(args.metric, measure).replace("-f ", "").replace(final_metric, "").replace("--measure " + measure, "")
     command = command.replace(ori_prediction, args.prediction)
-    command += " -m instr_count"
+    command += f" -m {measure}"
 
     if args.dataset in ["codeparrot/apps", "deepmind/code_contests", "file"] and "generator" not in args.extra_options:
         args.extra_options = "generator"
         command += " -e generator"
-    
-    args.metric = "instr_count"
+
+    args.metric = measure
     print(f"Executing Command: {command}...")
     args.command = command
     eval(args)
     print(colored("Done!", "green"))
 
-    print(colored("Measurement Finished. CPU instruction count results stored into {}".format(args.prediction.replace("_PASSED_SOLUTIONS.json", "_STRESSFUL_INSTRUCTION.json")), "green"))
-    
+    print(colored("Measurement Finished. Results stored into {}".format(args.prediction.replace("_PASSED_SOLUTIONS.json", result_suffix)), "green"))
+
     print(colored("+++++++++++Step 4: Calculating Metrics...", "green"))
     args.final_metric = final_metric
     args.single_worker = False
-    command = 'coffe eval ' + ' '.join(sys.argv[2:])
-    command = command.replace(ori_prediction, args.prediction.replace("_PASSED_SOLUTIONS.json", "_indexes.json") + "," + args.prediction.replace("_PASSED_SOLUTIONS.json", "_STRESSFUL_INSTRUCTION.json"))
-    command += " -m instr_count"
-    args.prediction =  args.prediction.replace("_PASSED_SOLUTIONS.json", "_indexes.json") + "," + args.prediction.replace("_PASSED_SOLUTIONS.json", "_STRESSFUL_INSTRUCTION.json")
-    args.metric = "instr_count"
+    command = 'coffe eval ' + ' '.join(sys.argv[2:]).replace("--measure " + measure, "")
+    command = command.replace(ori_prediction, args.prediction.replace("_PASSED_SOLUTIONS.json", "_indexes.json") + "," + args.prediction.replace("_PASSED_SOLUTIONS.json", result_suffix))
+    command += f" -m {measure}"
+    args.prediction = args.prediction.replace("_PASSED_SOLUTIONS.json", "_indexes.json") + "," + args.prediction.replace("_PASSED_SOLUTIONS.json", result_suffix)
+    args.metric = measure
     print(f"Executing Command: {command}...")
     args.command = command
     eval(args)
@@ -268,6 +277,7 @@ def main():
     pipeline_parser.add_argument('-e', '--extra_options', required = False, default = "", type = str, help = "Extra options for the evaluation")
     pipeline_parser.add_argument('-x', '--host_machine', required = False, default = False, action = "store_true", help = "Running code on host machine instead of calling docker containers. DANGEROUS!")
     pipeline_parser.add_argument('-f', '--final_metric', required = False, type = str, help = "The final metric calculated based on the measurement results, can be speedup or efficient_at_1.")
+    pipeline_parser.add_argument('--measure', required = False, default = 'instr_count', choices = ['instr_count', 'time'], help = "Measurement method: instr_count (default, requires Linux) or time (works on macOS via Docker).")
     pipeline_parser.set_defaults(func = pipe)
 
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# COFFE Mac Setup Script
+# Run this from the root of the Coffe repo:
+#   chmod +x setup_mac.sh
+#   ./setup_mac.sh
+
+set -e  # exit immediately on any error
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo ""
+echo -e "${BLUE}========================================"
+echo -e "   COFFE Mac Setup"
+echo -e "========================================${NC}"
+echo ""
+
+# ─── Verify we're in the repo root ────────────────────────────────────────────
+
+if [ ! -f "Dockerfile" ] || [ ! -f "setup.py" ]; then
+    echo -e "${RED}Error: Run this script from the root of the Coffe repo.${NC}"
+    echo "Example:  cd Coffe-3Llamas && ./setup_mac.sh"
+    exit 1
+fi
+
+REPO_DIR=$(pwd)
+WORKSPACE_DIR=$(dirname "$REPO_DIR")
+REPO_NAME=$(basename "$REPO_DIR")
+
+echo "Repo:      $REPO_DIR"
+echo "Workspace: $WORKSPACE_DIR"
+echo ""
+
+# ─── Prerequisite checks ──────────────────────────────────────────────────────
+
+echo -e "${BLUE}Checking prerequisites...${NC}"
+echo ""
+
+# Python 3.10+
+PYTHON_MAJOR=$(python3 -c 'import sys; print(sys.version_info.major)')
+PYTHON_MINOR=$(python3 -c 'import sys; print(sys.version_info.minor)')
+PYTHON_VERSION="$PYTHON_MAJOR.$PYTHON_MINOR"
+
+if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 10 ]; }; then
+    echo -e "${RED}✗ Python 3.10+ required. Found Python $PYTHON_VERSION.${NC}"
+    echo "  Install a newer version from https://python.org or via: brew install python@3.11"
+    exit 1
+fi
+echo -e "${GREEN}✓ Python $PYTHON_VERSION${NC}"
+
+# Docker installed
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}✗ Docker not found.${NC}"
+    echo "  Install Docker Desktop for Mac from https://www.docker.com/products/docker-desktop/"
+    exit 1
+fi
+echo -e "${GREEN}✓ Docker installed${NC}"
+
+# Docker running
+if ! docker info &> /dev/null 2>&1; then
+    echo -e "${RED}✗ Docker Desktop is not running.${NC}"
+    echo "  Open Docker Desktop, wait until the menu bar icon shows 'Running', then try again."
+    exit 1
+fi
+echo -e "${GREEN}✓ Docker Desktop is running${NC}"
+
+# pipenv installed
+if ! command -v pipenv &> /dev/null; then
+    echo -e "${RED}✗ pipenv not found.${NC}"
+    echo "  Install it with: pip install pipenv"
+    exit 1
+fi
+echo -e "${GREEN}✓ pipenv found${NC}"
+
+echo ""
+
+# ─── Step 1: Install coffe ────────────────────────────────────────────────────
+
+echo -e "${BLUE}[Step 1/3] Installing coffe into pipenv...${NC}"
+pipenv run pip install -e .
+echo -e "${GREEN}✓ coffe installed (editable mode — code changes apply instantly)${NC}"
+echo ""
+
+# ─── Step 2: Build Docker image ───────────────────────────────────────────────
+
+echo -e "${BLUE}[Step 2/3] Building Docker image...${NC}"
+echo -e "${YELLOW}Note: You will see a warning about CPU instruction counting — this is expected on Mac.${NC}"
+echo ""
+echo "running: docker build --no-cache . -t coffe"
+docker build --no-cache . -t coffe
+echo ""
+echo -e "${GREEN}✓ Docker image built${NC}"
+echo ""
+
+# ─── Step 3: Initialize coffe ─────────────────────────────────────────────────
+
+echo -e "${BLUE}[Step 3/3] Initializing coffe...${NC}"
+echo -e "${YELLOW}Note: The yellow warning below about instruction counting is expected on Mac.${NC}"
+echo ""
+cd "$WORKSPACE_DIR"
+pipenv run coffe init \
+    -d "$REPO_NAME/datasets" \
+    -w "$WORKSPACE_DIR" \
+    -p "$REPO_NAME/perf.json"
+echo ""
+echo -e "${GREEN}✓ coffe initialized — coffe_init.json written to $WORKSPACE_DIR${NC}"
+
+# ─── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}========================================"
+echo -e "   Setup complete!"
+echo -e "========================================${NC}"
+echo ""
+echo "To run an evaluation, open a new terminal and run:"
+echo ""
+echo -e "  cd $WORKSPACE_DIR"
+echo -e "  coffe pipe function $REPO_NAME/examples/function \\"
+echo -e "    -p $REPO_NAME/examples/function/GPT-4o.json \\"
+echo -e "    -f efficient_at_1 \\"
+echo -e "    -n 4 \\"
+echo -e "    --measure time"
+echo ""
+echo -e "${YELLOW}Reminder: Docker Desktop must be open and running before each evaluation.${NC}"
+echo ""


### PR DESCRIPTION
Overview: Added Mac OS system-specific setup instructions for coffe onto the README.md file. A Mac setup script was also created to be run on installation and do a lot of the heavy lifting in terms of setup/installation. Additionally, the existing time measurement option is made available through the inclusion of a specific flag when running coffe, previously, this option was unreachable by the user unless code was adjusted.

What was added?

setup_mac.sh: runs prerequesite checks like checking repo loaction, checking if necessary packages are already installed on the system, verifies Docker installation and correct accessibility. All checks provide feedback to user on what specifics should be fixed or added before proceeding to install coffe. Next, it installs coffe, builds the designated Docker image, and initializes coffe. Again, it provides adequate messages and notifications regarding any adjustments the user must make for these steps. Most importantly notifying the user that with Mac, CPU instruction counting is not available, and that wall-clock time measurement will be used instead. Previously, the pipeline would previously run but would silently fail as instruction counting on Mac produced invalid results, not providing the user with any useful data.

Wall-clock time measurement option: Previous to adjustment, coffe only ever attempts/uses instruction count regardless of OS system and does not make use or give the option for the alternative choice of measuring performance by wall-clock time. The feature of measuring wall-clock time is something that is already fully implemented in coffe, but it is never accessed or utilized in any context. With the inclusion of a --measure flag on the command for running coffe, non-Mac users now have access to using wall-clock measurement if they prefer over instruction counting. The inclusion of this flag is only necessary if wall-clock time measurement is preferred, else the system defaults to utilizing CPU instruction count.

Documentation: Instructions for using the Mac setup script and setting up the rest of the Mac OS system for coffe are now part of the README.md file, and the use and availability of the Wall-clock time measurement option is also explained and detailed on how to use exactly.

Results:

GPT-4o scored 48.95% function on wall-clock time measurement matching somewhat nicely to GPT-4o for functions on CPU instruction count: 44.59%, validating that this form of measurement can produce trustworthy results and adequately functions with the pipeline.
